### PR TITLE
Fixed code for 08-Recovery State

### DIFF
--- a/Polaris/src/states/Recovery.cpp
+++ b/Polaris/src/states/Recovery.cpp
@@ -8,7 +8,7 @@ void Recovery::initialize_impl() {}
 void Recovery::loop_impl() {}
 
 State *Recovery::nextState_impl() {
-
+    return nullptr;
 }
 
 enum StateId Recovery::getId()

--- a/Polaris/src/states/Recovery.h
+++ b/Polaris/src/states/Recovery.h
@@ -6,17 +6,4 @@ class Recovery : public State {
 	_STATE_CLASS_IMPLS_
 	public:
 		Recovery(FlashChip *flash, StateEstimator *stateEstimator, XbeeProSX *xbee, struct Servos *servos, OpenMV *openMV); 
-	private: 
-		// for z acceleration //I need to clarify why these are here 
-		float transitionBufAcc[10]; 
-		uint8_t transitionBufIndAcc = 0;
-		
-		// for vertical velocity
-		int16_t transitionBufVelVert[10];
-		uint8_t transitionBufIndVelVert = 0;
-
-		// Altitude buffer
-		int16_t transitionBufAlt[10];
-		uint8_t transitionBufIndAlt = 0;
-		int16_t altitudePreviousAvg;
 };


### PR DESCRIPTION
Add a return nullptr; line for the next state, since it was missing it before hand. Additionally, deleted the copy-paste private variables from the header file. Branch successfully built.